### PR TITLE
Add :terminal colors

### DIFF
--- a/colors/jellyx.vim
+++ b/colors/jellyx.vim
@@ -245,6 +245,31 @@ if exists('g:jellyx_show_whitespace')
     HI TrailingWS   -       89      -
 endif
 
+""" Terminal
+
+let g:terminal_color_0 = "#101010"
+let g:terminal_color_1 = "#df8787"
+let g:terminal_color_2 = "#afdf87"
+let g:terminal_color_3 = "#f6f6b6"
+let g:terminal_color_4 = "#87afdf"
+let g:terminal_color_5 = "#dfdf87"
+let g:terminal_color_6 = "#b6e0f6"
+let g:terminal_color_7 = "#dddddd"
+let g:terminal_color_8 = "#080808"
+let g:terminal_color_9 = "#df8787"
+let g:terminal_color_10 = "#afdf87"
+let g:terminal_color_11 = "#f6f6b6"
+let g:terminal_color_12 = "#87afdf"
+let g:terminal_color_13 = "#dfdf87"
+let g:terminal_color_14 = "#b6e0f6"
+let g:terminal_color_15 = "#ffffff"
+
+let g:terminal_ansi_colors=[
+    \ g:terminal_color_0, g:terminal_color_1, g:terminal_color_2, g:terminal_color_3,
+    \ g:terminal_color_4, g:terminal_color_5, g:terminal_color_6, g:terminal_color_7,
+    \ g:terminal_color_8, g:terminal_color_9, g:terminal_color_10, g:terminal_color_11,
+    \ g:terminal_color_12, g:terminal_color_13, g:terminal_color_14, g:terminal_color_15 ]
+
 """ Cleanup
 
 delcommand  HI


### PR DESCRIPTION
Thanks for creating my favorite theme. :)

When using `set termguicolors` and the embedded `:terminal`, Vim uses a default 16-color palate that is almost unreadable with a dark background. 

I've shamelessly [ripped](https://github.com/neozenith/estilo-xoria256/blob/master/colors/xoria256.vim#L230) these colors from @neozenith's [estilo-xoria256](https://github.com/neozenith/estilo-xoria256) Neovim theme. To get them to work with Vim as well, I've added them to the `g:terminal_ansi_colors` array.

## Screenshot
<img width="1220" alt="Screen Shot 2022-08-15 at 3 38 59 PM" src="https://user-images.githubusercontent.com/458926/184734815-62866a34-b282-429b-9f7a-cc653b794b67.png">

